### PR TITLE
Add some bounds

### DIFF
--- a/servant-swagger.cabal
+++ b/servant-swagger.cabal
@@ -45,12 +45,12 @@ library
     Servant.Swagger.Internal.TypeLevel.TMap
   hs-source-dirs:      src
   build-depends:       aeson
-                     , base >=4.7 && <5
+                     , base >=4.7 && <4.9
                      , bytestring
                      , http-media
                      , lens
-                     , servant
-                     , swagger2 >= 2.0.1 && <3
+                     , servant  >= 0.4.4.5 && <0.6
+                     , swagger2 >= 2.0.1   && <3
                      , text
                      , unordered-containers
 


### PR DESCRIPTION
because otherwise with ghc-8.0 `servant-0.2.2` is picked, as it's green with GHC8: http://matrix.hackage.haskell.org/package/servant