### PR TITLE
loosen deps to allow servant-swagger 0.7

### DIFF
--- a/servant-swagger.cabal
+++ b/servant-swagger.cabal
@@ -49,7 +49,7 @@ library
                      , bytestring
                      , http-media
                      , lens
-                     , servant  >= 0.4.4.5 && <0.7
+                     , servant  >= 0.4.4.5 && <0.8
                      , swagger2 >= 2.0.1   && <3
                      , text
                      , unordered-containers


### PR DESCRIPTION
I've tested this locally and everything compiles under servant-0.7.