### PR TITLE
Pretty print validation errors in validateEveryToJSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+next
+-----
+
+* Fixes:
+  * `validateEveryToJSON` now prints validation errors
+
 1.1.5
 -----
 

--- a/servant-swagger.cabal
+++ b/servant-swagger.cabal
@@ -73,6 +73,7 @@ library
     Servant.Swagger.Internal.TypeLevel.TMap
   hs-source-dirs:      src
   build-depends:       aeson                     >=0.11.2.0 && <1.5
+                     , aeson-pretty              >=0.4      && <0.9
                      , base                      >=4.7.0.0  && <4.12
                      , bytestring                >=0.10.4.0 && <0.11
                      , http-media                >=0.6.3    && <0.8

--- a/src/Servant/Swagger/Internal.hs
+++ b/src/Servant/Swagger/Internal.hs
@@ -1,13 +1,13 @@
-{-# LANGUAGE CPP #-}
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE PolyKinds #-}
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeOperators #-}
-{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE CPP                  #-}
+{-# LANGUAGE ConstraintKinds      #-}
+{-# LANGUAGE DataKinds            #-}
+{-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE FlexibleInstances    #-}
+{-# LANGUAGE OverloadedStrings    #-}
+{-# LANGUAGE PolyKinds            #-}
+{-# LANGUAGE RankNTypes           #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE TypeOperators        #-}
 #if __GLASGOW_HASKELL__ >= 710
 #define OVERLAPPABLE_ {-# OVERLAPPABLE #-}
 #else
@@ -16,25 +16,26 @@
 #endif
 module Servant.Swagger.Internal where
 
-import Control.Lens
-import Data.Aeson
-import Data.Monoid
-import Data.Proxy
-import qualified Data.Swagger as Swagger
-import Data.Swagger hiding (Header)
-import Data.Swagger.Declare
-import Data.HashMap.Strict.InsOrd (InsOrdHashMap)
-import qualified Data.HashMap.Strict.InsOrd  as InsOrdHashMap
-import Data.Text (Text)
-import qualified Data.Text as Text
-import GHC.TypeLits
-import Network.HTTP.Media (MediaType)
-import Servant.API
-import Servant.API.Description (FoldDescription, reflectDescription)
-import Servant.API.Modifiers (FoldRequired)
-import Data.Singletons.Bool
+import           Control.Lens
+import           Data.Aeson
+import           Data.HashMap.Strict.InsOrd             (InsOrdHashMap)
+import qualified Data.HashMap.Strict.InsOrd             as InsOrdHashMap
+import           Data.Monoid
+import           Data.Proxy
+import           Data.Singletons.Bool
+import           Data.Swagger                           hiding (Header)
+import qualified Data.Swagger                           as Swagger
+import           Data.Swagger.Declare
+import           Data.Text                              (Text)
+import qualified Data.Text                              as Text
+import           GHC.TypeLits
+import           Network.HTTP.Media                     (MediaType)
+import           Servant.API
+import           Servant.API.Description                (FoldDescription,
+                                                         reflectDescription)
+import           Servant.API.Modifiers                  (FoldRequired)
 
-import Servant.Swagger.Internal.TypeLevel.API
+import           Servant.Swagger.Internal.TypeLevel.API
 
 -- | Generate a Swagger specification for a servant API.
 --

--- a/src/Servant/Swagger/Internal.hs
+++ b/src/Servant/Swagger/Internal.hs
@@ -120,15 +120,15 @@ mkEndpointWithSchemaRef :: forall cs hs proxy method status a.
 mkEndpointWithSchemaRef mref path _ = mempty
   & paths.at path ?~
     (mempty & method ?~ (mempty
-      & produces ?~ MimeList contentTypes
+      & produces ?~ MimeList responseContentTypes
       & at code ?~ Inline (mempty
             & schema  .~ mref
             & headers .~ responseHeaders)))
   where
-    method          = swaggerMethod (Proxy :: Proxy method)
-    code            = fromIntegral (natVal (Proxy :: Proxy status))
-    contentTypes    = allContentType (Proxy :: Proxy cs)
-    responseHeaders = toAllResponseHeaders (Proxy :: Proxy hs)
+    method               = swaggerMethod (Proxy :: Proxy method)
+    code                 = fromIntegral (natVal (Proxy :: Proxy status))
+    responseContentTypes = allContentType (Proxy :: Proxy cs)
+    responseHeaders      = toAllResponseHeaders (Proxy :: Proxy hs)
 
 -- | Add parameter to every operation in the spec.
 addParam :: Param -> Swagger -> Swagger
@@ -356,9 +356,9 @@ instance AllToResponseHeader '[] where
   toAllResponseHeaders _ = mempty
 
 instance (ToResponseHeader h, AllToResponseHeader hs) => AllToResponseHeader (h ': hs) where
-  toAllResponseHeaders _ = InsOrdHashMap.insert hname header hdrs
+  toAllResponseHeaders _ = InsOrdHashMap.insert headerName headerBS hdrs
     where
-      (hname, header) = toResponseHeader (Proxy :: Proxy h)
+      (headerName, headerBS) = toResponseHeader (Proxy :: Proxy h)
       hdrs = toAllResponseHeaders (Proxy :: Proxy hs)
 
 instance AllToResponseHeader hs => AllToResponseHeader (HList hs) where

--- a/src/Servant/Swagger/Internal/Test.hs
+++ b/src/Servant/Swagger/Internal/Test.hs
@@ -139,11 +139,12 @@ props _ f px = sequence_ specs
 -- (using 'encodePretty').
 --
 -- >>> import Data.Aeson
+-- >>> import Data.Foldable (traverse_)
 -- >>> data Person = Person { name :: String, phone :: Integer } deriving (Generic)
 -- >>> instance ToJSON Person where toJSON p = object [ "name" .= name p ]
 -- >>> instance ToSchema Person
 -- >>> let person = Person { name = "John", phone = 123456 }
--- >>> mapM_ putStrLn $ prettyValidateWith validateToJSON person
+-- >>> traverse_ putStrLn $ prettyValidateWith validateToJSON person
 -- Validation against the schema fails:
 --   * property "phone" is required, but not found in "{\"name\":\"John\"}"
 -- <BLANKLINE>

--- a/src/Servant/Swagger/Internal/Test.hs
+++ b/src/Servant/Swagger/Internal/Test.hs
@@ -1,21 +1,27 @@
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ConstraintKinds     #-}
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeOperators #-}
-{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE TypeOperators       #-}
 module Servant.Swagger.Internal.Test where
 
-import Data.Aeson (ToJSON)
-import Data.Swagger
-import Data.Text (Text)
-import Data.Typeable
-import Test.Hspec
-import Test.Hspec.QuickCheck
-import Test.QuickCheck (Arbitrary, Property, property, counterexample)
+import           Data.Aeson                         (ToJSON (..))
+import           Data.Aeson.Encode.Pretty           (encodePretty)
+import           Data.Swagger                       (Pattern, ToSchema,
+                                                     toSchema)
+import           Data.Swagger.Schema.Validation
+import           Data.Text                          (Text)
+import qualified Data.Text.Lazy                     as TL
+import qualified Data.Text.Lazy.Encoding            as TL
+import           Data.Typeable
+import           Test.Hspec
+import           Test.Hspec.QuickCheck
+import           Test.QuickCheck                    (Arbitrary, Property,
+                                                     counterexample, property)
 
-import Servant.API
-import Servant.Swagger.Internal.TypeLevel
+import           Servant.API
+import           Servant.Swagger.Internal.TypeLevel
 
 -- $setup
 -- >>> import Control.Applicative
@@ -76,7 +82,7 @@ validateEveryToJSON :: forall proxy api. TMap (Every [Typeable, Show, Arbitrary,
   -> Spec
 validateEveryToJSON _ = props
   (Proxy :: Proxy [ToJSON, ToSchema])
-  (reportErrors . validateToJSON)
+  (maybeCounterExample . prettyValidateWith validateToJSON)
   (Proxy :: Proxy (BodyTypes JSON api))
 
 -- | Verify that every type used with @'JSON'@ content type in a servant API
@@ -89,7 +95,7 @@ validateEveryToJSONWithPatternChecker :: forall proxy api. TMap (Every [Typeable
   -> Spec
 validateEveryToJSONWithPatternChecker checker _ = props
   (Proxy :: Proxy [ToJSON, ToSchema])
-  (reportErrors . validateToJSONWithPatternChecker checker)
+  (maybeCounterExample . prettyValidateWith (validateToJSONWithPatternChecker checker))
   (Proxy :: Proxy (BodyTypes JSON api))
 
 -- * QuickCheck-related stuff
@@ -128,11 +134,65 @@ props _ f px = sequence_ specs
     aprop :: forall p' a. (EveryTF cs a, Typeable a, Show a, Arbitrary a) => p' a -> Spec
     aprop _ = prop (show (typeOf (undefined :: a))) (f :: a -> Property)
 
--- | A property that prints a nicely formatted list of errors if there are
--- any.
-reportErrors :: [ValidationError] -> Property
-reportErrors [] = property True
-reportErrors ex = counterexample errString (property False)
+-- | Pretty print validation errors
+-- together with actual JSON and Swagger Schema
+-- (using 'encodePretty').
+--
+-- >>> import Data.Aeson
+-- >>> data Person = Person { name :: String, phone :: Integer } deriving (Generic)
+-- >>> instance ToJSON Person where toJSON p = object [ "name" .= name p ]
+-- >>> instance ToSchema Person
+-- >>> let person = Person { name = "John", phone = 123456 }
+-- >>> mapM_ putStrLn $ prettyValidateWith validateToJSON person
+-- Validation against the schema fails:
+--   * property "phone" is required, but not found in "{\"name\":\"John\"}"
+-- <BLANKLINE>
+-- JSON value:
+-- {
+--     "name": "John"
+-- }
+-- <BLANKLINE>
+-- Swagger Schema:
+-- {
+--     "required": [
+--         "name",
+--         "phone"
+--     ],
+--     "type": "object",
+--     "properties": {
+--         "phone": {
+--             "type": "integer"
+--         },
+--         "name": {
+--             "type": "string"
+--         }
+--     }
+-- }
+-- <BLANKLINE>
+--
+-- FIXME: this belongs in "Data.Swagger.Schema.Validation" (in @swagger2@).
+prettyValidateWith
+  :: forall a. (ToJSON a, ToSchema a)
+  => (a -> [ValidationError]) -> a -> Maybe String
+prettyValidateWith f x =
+  case f x of
+    []      -> Nothing
+    errors  -> Just $ unlines
+      [ "Validation against the schema fails:"
+      , unlines (map ("  * " ++) errors)
+      , "JSON value:"
+      , ppJSONString json
+      , ""
+      , "Swagger Schema:"
+      , ppJSONString (toJSON schema)
+      ]
   where
-    errString = unlines $ "Validation against the schema fails:"
-                        : map ("  * " ++) ex
+    ppJSONString = TL.unpack . TL.decodeUtf8 . encodePretty
+
+    json   = toJSON x
+    schema = toSchema (Proxy :: Proxy a)
+
+-- | Provide a counterexample if there is any.
+maybeCounterExample :: Maybe String -> Property
+maybeCounterExample Nothing  = property True
+maybeCounterExample (Just s) = counterexample s (property False)

--- a/src/Servant/Swagger/Internal/TypeLevel.hs
+++ b/src/Servant/Swagger/Internal/TypeLevel.hs
@@ -4,6 +4,6 @@ module Servant.Swagger.Internal.TypeLevel (
   module Servant.Swagger.Internal.TypeLevel.TMap,
 ) where
 
-import Servant.Swagger.Internal.TypeLevel.API
-import Servant.Swagger.Internal.TypeLevel.Every
-import Servant.Swagger.Internal.TypeLevel.TMap
+import           Servant.Swagger.Internal.TypeLevel.API
+import           Servant.Swagger.Internal.TypeLevel.Every
+import           Servant.Swagger.Internal.TypeLevel.TMap

--- a/src/Servant/Swagger/Internal/TypeLevel/API.hs
+++ b/src/Servant/Swagger/Internal/TypeLevel/API.hs
@@ -1,15 +1,15 @@
-{-# LANGUAGE ConstraintKinds #-}
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE KindSignatures #-}
-{-# LANGUAGE PolyKinds #-}
-{-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE ConstraintKinds      #-}
+{-# LANGUAGE DataKinds            #-}
+{-# LANGUAGE KindSignatures       #-}
+{-# LANGUAGE PolyKinds            #-}
+{-# LANGUAGE TypeFamilies         #-}
+{-# LANGUAGE TypeOperators        #-}
 {-# LANGUAGE UndecidableInstances #-}
 module Servant.Swagger.Internal.TypeLevel.API where
 
-import Data.Type.Bool (If)
-import Servant.API
-import GHC.Exts (Constraint)
+import           Data.Type.Bool (If)
+import           GHC.Exts       (Constraint)
+import           Servant.API
 
 -- | Build a list of endpoints from an API.
 type family EndpointsList api where

--- a/src/Servant/Swagger/Internal/TypeLevel/Every.hs
+++ b/src/Servant/Swagger/Internal/TypeLevel/Every.hs
@@ -1,27 +1,27 @@
-{-# LANGUAGE CPP #-}
-{-# LANGUAGE ConstraintKinds #-}
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE GADTs #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE InstanceSigs #-}
-{-# LANGUAGE KindSignatures #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE PolyKinds #-}
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
-{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE CPP                     #-}
+{-# LANGUAGE ConstraintKinds         #-}
+{-# LANGUAGE DataKinds               #-}
+{-# LANGUAGE FlexibleContexts        #-}
+{-# LANGUAGE FlexibleInstances       #-}
+{-# LANGUAGE GADTs                   #-}
+{-# LANGUAGE InstanceSigs            #-}
+{-# LANGUAGE KindSignatures          #-}
+{-# LANGUAGE MultiParamTypeClasses   #-}
+{-# LANGUAGE PolyKinds               #-}
+{-# LANGUAGE RankNTypes              #-}
+{-# LANGUAGE ScopedTypeVariables     #-}
+{-# LANGUAGE TypeFamilies            #-}
+{-# LANGUAGE TypeOperators           #-}
+{-# LANGUAGE UndecidableInstances    #-}
 #if __GLASGOW_HASKELL__ >= 800
 {-# LANGUAGE UndecidableSuperClasses #-}
 #endif
 module Servant.Swagger.Internal.TypeLevel.Every where
 
-import Data.Proxy
-import GHC.Exts (Constraint)
+import           Data.Proxy
+import           GHC.Exts                                (Constraint)
 
-import Servant.Swagger.Internal.TypeLevel.TMap
+import           Servant.Swagger.Internal.TypeLevel.TMap
 
 -- $setup
 -- >>> :set -XDataKinds

--- a/src/Servant/Swagger/Internal/TypeLevel/TMap.hs
+++ b/src/Servant/Swagger/Internal/TypeLevel/TMap.hs
@@ -1,17 +1,17 @@
-{-# LANGUAGE ConstraintKinds #-}
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE ConstraintKinds       #-}
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE KindSignatures        #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE PolyKinds #-}
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeOperators #-}
-{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE PolyKinds             #-}
+{-# LANGUAGE RankNTypes            #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE TypeOperators         #-}
+{-# LANGUAGE UndecidableInstances  #-}
 module Servant.Swagger.Internal.TypeLevel.TMap where
 
-import Data.Proxy
-import GHC.Exts (Constraint)
+import           Data.Proxy
+import           GHC.Exts   (Constraint)
 
 -- $setup
 -- >>> :set -XDataKinds

--- a/src/Servant/Swagger/Test.hs
+++ b/src/Servant/Swagger/Test.hs
@@ -10,4 +10,4 @@ module Servant.Swagger.Test (
   validateEveryToJSONWithPatternChecker,
 ) where
 
-import Servant.Swagger.Internal.Test
+import           Servant.Swagger.Internal.Test

--- a/src/Servant/Swagger/TypeLevel.hs
+++ b/src/Servant/Swagger/TypeLevel.hs
@@ -11,5 +11,5 @@ module Servant.Swagger.TypeLevel (
   BodyTypes,
 ) where
 
-import Servant.Swagger.Internal.TypeLevel
+import           Servant.Swagger.Internal.TypeLevel
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,4 @@
-resolver: nightly-2016-10-10
+resolver: lts-11.7
 packages:
 - '.'
 - example/
-extra-deps:
-- lens-4.15


### PR DESCRIPTION
This is a slight improvement on the work of @neongreen in #83.

I've added pretty-printed JSON value and Swagger Schema for more context:

```
Validation against the schema fails:
  * property "phone" is required, but not found in "{\"name\":\"John\"}"

JSON value:
{
    "name": "John"
}

Swagger Schema:
{
    "required": [
        "name",
        "phone"
    ],
    "type": "object",
    "properties": {
        "phone": {
            "type": "integer"
        },
        "name": {
            "type": "string"
        }
    }
}
```

I've also applied stylish-haskell formatting to the sources, updated `stack.yaml` and fixed two minor warnings.