### PR TITLE
Swagger is not a trademark

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Swagger 2.0 conforming json for [servant](https://github.com/haskell-servant/ser
 
 ### Motivation
 
-Swagger™ is a project used to describe and document RESTful APIs.
+Swagger is a project used to describe and document RESTful APIs.
 Unlike Servant it is language-agnostic and thus is quite popular among developers
 in different languages. It also exists for a longer time and has more tools to work with.
 

--- a/servant-swagger.cabal
+++ b/servant-swagger.cabal
@@ -3,7 +3,7 @@ version:             1.1.5
 x-revision:          4
 synopsis:            Generate Swagger specification for your servant API.
 description:
-  Swagger™ is a project used to describe and document RESTful APIs.
+  Swagger is a project used to describe and document RESTful APIs.
   Unlike Servant it is language-agnostic and thus is quite popular among developers
   in different languages. It also exists for a longer time and has more tools to work with.
   .

--- a/src/Servant/Swagger.hs
+++ b/src/Servant/Swagger.hs
@@ -7,14 +7,14 @@
 -- This module provides means to generate and manipulate
 -- Swagger specification for servant APIs.
 --
--- Swagger™ is a project used to describe and document RESTful APIs.
+-- Swagger is a project used to describe and document RESTful APIs.
 --
 -- The Swagger specification defines a set of files required to describe such an API.
 -- These files can then be used by the Swagger-UI project to display the API
 -- and Swagger-Codegen to generate clients in various languages.
 -- Additional utilities can also take advantage of the resulting files, such as testing tools.
 --
--- For more information see <http://swagger.io/ Swagger™ documentation>.
+-- For more information see <http://swagger.io/ Swagger documentation>.
 module Servant.Swagger (
   -- * How to use this library
   -- $howto


### PR DESCRIPTION
And even if it is, swagger.io itself does not label it as such, so
surely we don't have to, either.