### PR TITLE
Fix BodyTypes to work with generalized ReqBody'

### DIFF
--- a/src/Servant/Swagger/Internal/TypeLevel/API.hs
+++ b/src/Servant/Swagger/Internal/TypeLevel/API.hs
@@ -75,7 +75,7 @@ type AddBodyType c cs a as = If (Elem c cs) (a ': as) as
 type family BodyTypes' c api :: [*] where
   BodyTypes' c (Verb verb b cs (Headers hdrs a)) = AddBodyType c cs a '[]
   BodyTypes' c (Verb verb b cs a) = AddBodyType c cs a '[]
-  BodyTypes' c (ReqBody cs a :> api) = AddBodyType c cs a (BodyTypes' c api)
+  BodyTypes' c (ReqBody' mods cs a :> api) = AddBodyType c cs a (BodyTypes' c api)
   BodyTypes' c (e :> api) = BodyTypes' c api
   BodyTypes' c (a :<|> b) = AppendList (BodyTypes' c a) (BodyTypes' c b)
   BodyTypes' c api = '[]


### PR DESCRIPTION
I've recently discovered that `validateEveryToJSON` ignored my `ReqBody '[Description "...", ...]` types. This was because it only considered `ReqBody` which recently became a synonym for `ReqBody '[Required, Strict]` in `servant-0.13`. This PR fixes that.

If you can't update to the latest version of `servant-swagger`, you can use this workaround locally in the test suite:

```haskell
-- | Replace every @'ReqBody'' mods@ with 'ReqBody'
-- so that 'validateEveryToJSON' will work for request body types.
type family PatchAPI api where
  PatchAPI (ReqBody' mods cs a :> api) = ReqBody cs a :> PatchAPI api
  PatchAPI ((param :: k) :> api) = param :> PatchAPI api
  PatchAPI (left :<|> right) = PatchAPI left :<|> PatchAPI right
  PatchAPI api = api

...

spec :: Spec
spec = do
  describe "Swagger spec for MyAPI" $ do
    context "ToJSON matches ToSchema" $ do
      validateEveryToJSON (Proxy :: Proxy (PatchAPI MyAPI))
  ...
```