### PR TITLE
Support GHC-8.6 and base-4.12

### DIFF
--- a/servant-swagger.cabal
+++ b/servant-swagger.cabal
@@ -53,8 +53,8 @@ source-repository head
 
 custom-setup
   setup-depends:
-    base >=4.7 && <4.12,
-    Cabal >= 1.18 && <2.3,
+    base >=4.7 && <4.13,
+    Cabal >= 1.18 && <2.4,
     cabal-doctest >=1.0.2 && <1.1
 
 library
@@ -74,7 +74,7 @@ library
   hs-source-dirs:      src
   build-depends:       aeson                     >=0.11.2.0 && <1.5
                      , aeson-pretty              >=0.4      && <0.9
-                     , base                      >=4.7.0.0  && <4.12
+                     , base                      >=4.7.0.0  && <4.13
                      , bytestring                >=0.10.4.0 && <0.11
                      , http-media                >=0.6.3    && <0.8
                      , insert-ordered-containers >=0.1.0.0  && <0.3

--- a/src/Servant/Swagger/Internal.hs
+++ b/src/Servant/Swagger/Internal.hs
@@ -8,6 +8,9 @@
 {-# LANGUAGE RankNTypes           #-}
 {-# LANGUAGE ScopedTypeVariables  #-}
 {-# LANGUAGE TypeOperators        #-}
+#if __GLASGOW_HASKELL__ >= 806
+{-# LANGUAGE UndecidableInstances #-}
+#endif
 #if __GLASGOW_HASKELL__ >= 710
 #define OVERLAPPABLE_ {-# OVERLAPPABLE #-}
 #else
@@ -20,7 +23,9 @@ import           Control.Lens
 import           Data.Aeson
 import           Data.HashMap.Strict.InsOrd             (InsOrdHashMap)
 import qualified Data.HashMap.Strict.InsOrd             as InsOrdHashMap
+#if !MIN_VERSION_base(4,11,0)
 import           Data.Monoid
+#endif
 import           Data.Proxy
 import           Data.Singletons.Bool
 import           Data.Swagger                           hiding (Header)


### PR DESCRIPTION
Add support for GHC-8.6 and base-4.12. Tested with:

* [x] `cabal new-build -w ghc-8.6.1 --enable-tests --enable-bench --enable-doc --allow-newer=base,containers,template-haskell,Cabal`
* [x] `cabal new-test -w ghc-8.6.1 --enable-tests --enable-bench --enable-doc --allow-newer=base,containers,template-haskell,Cabal`

`example/` tested with:

* [x] `cabal new-build -w ghc-8.6.1 --enable-tests --enable-bench --enable-doc --allow-newer=base,containers,template-haskell,Cabal`
* [x] `cabal new-test -w ghc-8.6.1 --enable-tests --enable-bench --enable-doc --allow-newer=base,containers,template-haskell,Cabal`
* [x] `cabal new-run -w ghc-8.6.1 --enable-tests --enable-bench --enable-doc --allow-newer=base,containers,template-haskell,Cabal swagger-server`

The `--allow-newer` flags are required for building the dependencies but not for servant-swagger itself.