### PR TITLE
Problem with nested generic ToSchema instance and validateEveryToJSON

### DIFF
--- a/servant-swagger.cabal
+++ b/servant-swagger.cabal
@@ -116,6 +116,7 @@ test-suite spec
                   , aeson
                   , hspec >=2.6.0 && <2.8
                   , QuickCheck
+                  , quickcheck-instances
                   , lens
                   , lens-aeson >=1.0.2    && <1.1
                   , servant
@@ -126,6 +127,8 @@ test-suite spec
                   , utf8-string >=1.0.1.1 && <1.1
                   , time
                   , vector
+                  , insert-ordered-containers
+                  , uuid
   other-modules:
     Servant.SwaggerSpec
   default-language: Haskell2010

--- a/src/Servant/Swagger/Internal/Test.hs
+++ b/src/Servant/Swagger/Internal/Test.hs
@@ -185,13 +185,13 @@ prettyValidateWith f x =
       , ppJSONString json
       , ""
       , "Swagger Schema:"
-      , ppJSONString (toJSON schema)
+      , ppJSONString (toJSON schema_)
       ]
   where
     ppJSONString = TL.unpack . TL.decodeUtf8 . encodePretty
 
     json   = toJSON x
-    schema = toSchema (Proxy :: Proxy a)
+    schema_ = toSchema (Proxy :: Proxy a)
 
 -- | Provide a counterexample if there is any.
 maybeCounterExample :: Maybe String -> Property

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-11.7
+resolver: lts-13.23
 packages:
 - '.'
 - example/


### PR DESCRIPTION
This adds a failing test to the test suite, so this is more of an issue than a PR.

I think the cause is that the generic instance uses a reference to the UUID description instead of an inlined description, and then fails to add the target of the reference to the `descriptions` object.

Two work-arounds:

- use `Text` instead of `UUID` in the type.
- manually write a `ToSchema` instance for `Y`.

Not sure about the actual fix, but it may involve `BodyTypes` here in servant-swagger, or changing the generic instances in swagger2.