### PR TITLE
Correctly identify whether runing with GHC >= 8.8.1

### DIFF
--- a/src/Servant/Swagger/Internal/Orphans.hs
+++ b/src/Servant/Swagger/Internal/Orphans.hs
@@ -10,7 +10,7 @@ import           Data.Proxy
 import           Data.Swagger
 import           Servant.Types.SourceT
                  (SourceT)
-#if __GLASGOW_HASKELL__ >= 881
+#if MIN_VERSION_GLASGOW_HASKELL(8,8,1,0)
 import           Servant.API (WithStatus(..))
 #endif
 
@@ -21,7 +21,7 @@ import           Servant.API (WithStatus(..))
 instance ToSchema a => ToSchema (SourceT m a) where
     declareNamedSchema _ = declareNamedSchema (Proxy :: Proxy [a])
 
-#if __GLASGOW_HASKELL__ >= 881
+#if MIN_VERSION_GLASGOW_HASKELL(8,8,1,0)
 -- @since 1.1.11
 deriving instance ToSchema a => ToSchema (WithStatus s a)
 #endif


### PR DESCRIPTION
I find `__GLASGOW_HASKELL__` to be a confusing macro, the correct version for 881 would be `808`  as documented [here](https://downloads.haskell.org/~ghc/8.8-latest/docs/html/users_guide/phases.html#standard-cpp-macros). `MIN_VERSION_GLASGOW_HASKELL` is much better as it makes things clearer, but it would mean dropping support for GHC < 7.10, not sure if it was supported anyway.