### PR TITLE
Add HasSwagger instance for UVerb NoContent

### DIFF
--- a/src/Servant/Swagger/Internal.hs
+++ b/src/Servant/Swagger/Internal.hs
@@ -202,38 +202,55 @@ instance
   toSwagger _ =
     toSwagger (Proxy :: Proxy (Verb method (StatusOf a) cs a))
       `combineSwagger` toSwagger (Proxy :: Proxy (UVerb method cs as))
-    where
-      -- workaround for https://github.com/GetShopTV/swagger2/issues/218
-      -- We'd like to juse use (<>) but the instances are wrong
-      combinePathItem :: PathItem -> PathItem -> PathItem
-      combinePathItem s t = PathItem
-        { _pathItemGet = _pathItemGet s <> _pathItemGet t
-        , _pathItemPut = _pathItemPut s <> _pathItemPut t
-        , _pathItemPost = _pathItemPost s <> _pathItemPost t
-        , _pathItemDelete = _pathItemDelete s <> _pathItemDelete t
-        , _pathItemOptions = _pathItemOptions s <> _pathItemOptions t
-        , _pathItemHead = _pathItemHead s <> _pathItemHead t
-        , _pathItemPatch = _pathItemPatch s <> _pathItemPatch t
-        , _pathItemParameters = _pathItemParameters s <> _pathItemParameters t
-        }
 
-      combineSwagger :: Swagger -> Swagger -> Swagger
-      combineSwagger s t = Swagger
-        { _swaggerInfo = _swaggerInfo s <> _swaggerInfo t
-        , _swaggerHost = _swaggerHost s <|> _swaggerHost t
-        , _swaggerBasePath = _swaggerBasePath s <|> _swaggerBasePath t
-        , _swaggerSchemes = _swaggerSchemes s <> _swaggerSchemes t
-        , _swaggerConsumes = _swaggerConsumes s <> _swaggerConsumes t
-        , _swaggerProduces = _swaggerProduces s <> _swaggerProduces t
-        , _swaggerPaths = InsOrdHashMap.unionWith combinePathItem (_swaggerPaths s) (_swaggerPaths t)
-        , _swaggerDefinitions = _swaggerDefinitions s <> _swaggerDefinitions t
-        , _swaggerParameters = _swaggerParameters s <> _swaggerParameters t
-        , _swaggerResponses = _swaggerResponses s <> _swaggerResponses t
-        , _swaggerSecurityDefinitions = _swaggerSecurityDefinitions s <> _swaggerSecurityDefinitions t
-        , _swaggerSecurity = _swaggerSecurity s <> _swaggerSecurity t
-        , _swaggerTags = _swaggerTags s <> _swaggerTags t
-        , _swaggerExternalDocs = _swaggerExternalDocs s <|> _swaggerExternalDocs t
-        }
+-- ATTENTION: do not remove this instance!
+-- A similar instance above will always use the more general
+-- polymorphic -- HasSwagger instance and will result in a type error
+-- since 'NoContent' does not have a 'ToSchema' instance.
+instance
+  ( KnownNat status,
+    AllAccept cs,
+    SwaggerMethod method,
+    HasSwagger (UVerb method cs as)
+  ) =>
+  HasSwagger (UVerb method cs (WithStatus status NoContent ': as))
+  where
+  toSwagger _ =
+    toSwagger (Proxy :: Proxy (Verb method status cs NoContent))
+      `combineSwagger` toSwagger (Proxy :: Proxy (UVerb method cs as))
+
+
+-- workaround for https://github.com/GetShopTV/swagger2/issues/218
+-- We'd like to juse use (<>) but the instances are wrong
+combinePathItem :: PathItem -> PathItem -> PathItem
+combinePathItem s t = PathItem
+    { _pathItemGet = _pathItemGet s <> _pathItemGet t
+    , _pathItemPut = _pathItemPut s <> _pathItemPut t
+    , _pathItemPost = _pathItemPost s <> _pathItemPost t
+    , _pathItemDelete = _pathItemDelete s <> _pathItemDelete t
+    , _pathItemOptions = _pathItemOptions s <> _pathItemOptions t
+    , _pathItemHead = _pathItemHead s <> _pathItemHead t
+    , _pathItemPatch = _pathItemPatch s <> _pathItemPatch t
+    , _pathItemParameters = _pathItemParameters s <> _pathItemParameters t
+    }
+
+combineSwagger :: Swagger -> Swagger -> Swagger
+combineSwagger s t = Swagger
+    { _swaggerInfo = _swaggerInfo s <> _swaggerInfo t
+    , _swaggerHost = _swaggerHost s <|> _swaggerHost t
+    , _swaggerBasePath = _swaggerBasePath s <|> _swaggerBasePath t
+    , _swaggerSchemes = _swaggerSchemes s <> _swaggerSchemes t
+    , _swaggerConsumes = _swaggerConsumes s <> _swaggerConsumes t
+    , _swaggerProduces = _swaggerProduces s <> _swaggerProduces t
+    , _swaggerPaths = InsOrdHashMap.unionWith combinePathItem (_swaggerPaths s) (_swaggerPaths t)
+    , _swaggerDefinitions = _swaggerDefinitions s <> _swaggerDefinitions t
+    , _swaggerParameters = _swaggerParameters s <> _swaggerParameters t
+    , _swaggerResponses = _swaggerResponses s <> _swaggerResponses t
+    , _swaggerSecurityDefinitions = _swaggerSecurityDefinitions s <> _swaggerSecurityDefinitions t
+    , _swaggerSecurity = _swaggerSecurity s <> _swaggerSecurity t
+    , _swaggerTags = _swaggerTags s <> _swaggerTags t
+    , _swaggerExternalDocs = _swaggerExternalDocs s <|> _swaggerExternalDocs t
+    }
 
 instance {-# OVERLAPPABLE #-} (ToSchema a, AllAccept cs, KnownNat status, SwaggerMethod method) => HasSwagger (Verb method status cs a) where
   toSwagger _ = toSwagger (Proxy :: Proxy (Verb method status cs (Headers '[] a)))


### PR DESCRIPTION
Without this instance, using `NoContent` in a `UVerb` response causes an error because `NoContent` does not implement `ToSchema`, similar to the normal `Verb` instance