### PR TITLE
Adds Fragment instance

### DIFF
--- a/src/Servant/Swagger/Internal.hs
+++ b/src/Servant/Swagger/Internal.hs
@@ -267,6 +267,10 @@ instance (HasSwagger sub) => HasSwagger (IsSecure :> sub) where
 instance (HasSwagger sub) => HasSwagger (RemoteHost :> sub) where
   toSwagger _ = toSwagger (Proxy :: Proxy sub)
 
+-- | @'Fragment'@ combinator does not change our specification at all.
+instance HasSwagger sub => HasSwagger (Fragment a :> sub) where
+  toSwagger _ = toSwagger (Proxy :: Proxy sub)
+
 -- | @'HttpVersion'@ combinator does not change our specification at all.
 instance (HasSwagger sub) => HasSwagger (HttpVersion :> sub) where
   toSwagger _ = toSwagger (Proxy :: Proxy sub)


### PR DESCRIPTION
Fixes

```haskell
test/Servant/SwaggerSpec.hs:46:14: error:
    • No instance for (HasSwagger
                         (Fragment Int :> Servant.Test.ComprehensiveAPI.GET))
        arising from a use of ‘toSwagger’
    • In the expression: toSwagger comprehensiveAPI
      In an equation for ‘_x’: _x = toSwagger comprehensiveAPI
      In the second argument of ‘($)’, namely
        ‘do let _x = toSwagger comprehensiveAPI
            True `shouldBe` True’
   |
46 |     let _x = toSwagger comprehensiveAPI
```